### PR TITLE
support node-red v1 async send api

### DIFF
--- a/node/base.js
+++ b/node/base.js
@@ -19,7 +19,8 @@ module.exports = class TrelloApiNode {
             return [pathParams, queryParams];
         };
 
-        node.on("input", function(msg) {
+        node.on("input", function(msg, send, done) {
+            send = send || function() { node.send.apply(node,arguments) };
             var injectionConfig = msg.trello_config;
             if (typeof injectionConfig ==="object") {
                 trello = new Trello(
@@ -55,11 +56,18 @@ module.exports = class TrelloApiNode {
             var formattedPath = mustache.render(path, pathParams);
             var formattedQuery = JSON.parse(mustache.render(query, queryParams));
             trello.request(method, join("/1", formattedPath), formattedQuery, (err, data) => {
-                if (err) { 
-                    node.error(err, msg);
+                if (err) {
+                    if (done) {
+                        done(err);
+                    } else {
+                        node.error(err, msg);
+                    }
                 } else {
                     msg.payload = data;
-                    node.send(msg);
+                    send(msg);
+                    if (done) {
+                        done();
+                    }
                 }
             });
         });


### PR DESCRIPTION
The syntax for listening to an incoming message and sending a message is changing in Node-RED v1.
The post about this from the official Node-RED blog explains why it's changing, what's the new syntax, and how to maintain backward compatibility:
https://nodered.org/blog/2019/09/20/node-done

This PR changes the syntax based on the example from the blog post.

Thanks.